### PR TITLE
feat: Allow dynamic position change during timer operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsdtest-publish/
+
+/.cursor

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -53,6 +53,21 @@ This is the primary interface for setting up the timer. It must contain the foll
         - **Stop:** Terminates the timer and dismisses the timer bar.
 - The hover control panel should disappear when the cursor moves away from the timer bar area.
 
+### 3.3. Dynamic Position Change During Timer Operation
+
+- **Functionality**: Users shall be able to change the position of the timer bar while the timer is running.
+- **Timer State**: The timer's countdown must continue uninterrupted during the position change process.
+- **Trigger**: A "Change Position" button shall be added to the hover control panel.
+- **Process**:
+    - Clicking the "Change Position" button shall enter a "position selection mode."
+    - In this mode, icons representing the four possible positions (`Top Edge`, `Bottom Edge`, `Left Edge`, `Right Edge`) shall be displayed.
+    - Clicking one of these icons shall immediately move the timer bar to the selected position and exit the selection mode.
+- **Cancellation**: The position selection mode can be cancelled by one of the following actions, which will hide the position icons:
+    - Pressing the `Esc` key.
+    - Clicking the "Change Position" button again.
+    - Clicking anywhere on the screen outside of the position selection icons.
+- **Persistence**: The newly selected position shall be saved as the default for subsequent application launches.
+
 ## 4. Visual and Audio Cues
 
 ### 4.1. Color Progression

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -51,6 +51,10 @@ This is the primary interface for setting up the timer. It must contain the foll
     - This panel must provide buttons for:
         - **Pause/Resume:** Toggles the timer's countdown.
         - **Stop:** Terminates the timer and dismisses the timer bar.
+        - **Move:** Initiates the dynamic position change functionality.
+    - **Responsive Layout:** The control panel layout shall automatically adapt based on the timer bar position:
+        - **Top/Bottom Edge:** Control buttons are arranged horizontally to fit within the available width.
+        - **Left/Right Edge:** Control buttons are arranged vertically to fit within the available height.
 - The hover control panel should disappear when the cursor moves away from the timer bar area.
 
 ### 3.3. Dynamic Position Change During Timer Operation
@@ -59,12 +63,17 @@ This is the primary interface for setting up the timer. It must contain the foll
 - **Timer State**: The timer's countdown must continue uninterrupted during the position change process.
 - **Trigger**: A "Change Position" button shall be added to the hover control panel.
 - **Process**:
-    - Clicking the "Change Position" button shall enter a "position selection mode."
-    - In this mode, icons representing the four possible positions (`Top Edge`, `Bottom Edge`, `Left Edge`, `Right Edge`) shall be displayed.
-    - Clicking one of these icons shall immediately move the timer bar to the selected position and exit the selection mode.
+    - Clicking the "Move" button shall enter a "position selection mode."
+    - In this mode, a popup interface with directional arrow buttons representing the four possible positions shall be displayed:
+        - **↑** for `Top Edge`
+        - **↓** for `Bottom Edge`  
+        - **←** for `Left Edge`
+        - **→** for `Right Edge`
+        - **×** for cancellation
+    - The current position button shall be hidden to prevent redundant selection.
+    - Clicking one of these directional buttons shall immediately move the timer bar to the selected position and exit the selection mode.
 - **Cancellation**: The position selection mode can be cancelled by one of the following actions, which will hide the position icons:
-    - Pressing the `Esc` key.
-    - Clicking the "Change Position" button again.
+    - Clicking the cancel button (×) in the position selection interface.
     - Clicking anywhere on the screen outside of the position selection icons.
 - **Persistence**: The newly selected position shall be saved as the default for subsequent application launches.
 
@@ -111,4 +120,10 @@ The color of the timer bar must change dynamically to indicate the urgency of th
     - English (en-US)
     - Japanese (ja-JP)
     - Simplified Chinese (zh-CN)
-    - Traditional Chinese (zh-TW) 
+    - Traditional Chinese (zh-TW)
+- **Localized Components**: The following elements must support localization:
+    - Main window controls (buttons, labels, dropdown options)
+    - Timer control panel buttons (Pause/Resume, Stop, Move)
+    - Position selection interface (tooltips for directional buttons)
+    - System notifications and dialog messages
+    - Error messages and status indicators 

--- a/wpf/App.xaml
+++ b/wpf/App.xaml
@@ -94,6 +94,16 @@
             <Setter Property="Height" Value="{StaticResource ButtonHeight}"/>
         </Style>
 
+        <!-- Position Button Style -->
+        <Style x:Key="PositionButtonStyle" TargetType="Button" BasedOn="{StaticResource ControlButtonStyle}">
+            <Setter Property="FontSize" Value="24"/>
+            <Setter Property="Width" Value="50"/>
+            <Setter Property="Height" Value="50"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+
         <!-- Primary Button Style -->
         <Style x:Key="PrimaryButtonStyle" TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
             <Setter Property="Width" Value="{StaticResource LargeButtonWidth}"/>

--- a/wpf/Properties/Resources.Designer.cs
+++ b/wpf/Properties/Resources.Designer.cs
@@ -283,6 +283,72 @@ namespace RemMeter.Properties
         }
 
         /// <summary>
+        /// Looks up a localized string similar to Move.
+        /// </summary>
+        public static string Move
+        {
+            get
+            {
+                return ResourceManager.GetString("Move", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Move to top.
+        /// </summary>
+        public static string MoveToTop
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveToTop", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Move to bottom.
+        /// </summary>
+        public static string MoveToBottom
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveToBottom", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Move to left.
+        /// </summary>
+        public static string MoveToLeft
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveToLeft", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Move to right.
+        /// </summary>
+        public static string MoveToRight
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveToRight", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string CancelMove
+        {
+            get
+            {
+                return ResourceManager.GetString("CancelMove", resourceCulture);
+            }
+        }
+
+        /// <summary>
         /// Looks up a localized string similar to Timer.
         /// </summary>
         public static string Timer

--- a/wpf/Properties/Resources.ja-JP.resx
+++ b/wpf/Properties/Resources.ja-JP.resx
@@ -126,6 +126,24 @@
   <data name="Stop" xml:space="preserve">
     <value>停止</value>
   </data>
+  <data name="Move" xml:space="preserve">
+    <value>移動</value>
+  </data>
+  <data name="MoveToTop" xml:space="preserve">
+    <value>上端へ移動</value>
+  </data>
+  <data name="MoveToBottom" xml:space="preserve">
+    <value>下端へ移動</value>
+  </data>
+  <data name="MoveToLeft" xml:space="preserve">
+    <value>左端へ移動</value>
+  </data>
+  <data name="MoveToRight" xml:space="preserve">
+    <value>右端へ移動</value>
+  </data>
+  <data name="CancelMove" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
   <data name="Timer" xml:space="preserve">
     <value>タイマー</value>
   </data>

--- a/wpf/Properties/Resources.resx
+++ b/wpf/Properties/Resources.resx
@@ -126,6 +126,24 @@
   <data name="Stop" xml:space="preserve">
     <value>Stop</value>
   </data>
+  <data name="Move" xml:space="preserve">
+    <value>Move</value>
+  </data>
+  <data name="MoveToTop" xml:space="preserve">
+    <value>Move to top</value>
+  </data>
+  <data name="MoveToBottom" xml:space="preserve">
+    <value>Move to bottom</value>
+  </data>
+  <data name="MoveToLeft" xml:space="preserve">
+    <value>Move to left</value>
+  </data>
+  <data name="MoveToRight" xml:space="preserve">
+    <value>Move to right</value>
+  </data>
+  <data name="CancelMove" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
   <data name="Timer" xml:space="preserve">
     <value>Timer</value>
   </data>

--- a/wpf/Properties/Resources.zh-CN.resx
+++ b/wpf/Properties/Resources.zh-CN.resx
@@ -126,6 +126,24 @@
   <data name="Stop" xml:space="preserve">
     <value>停止</value>
   </data>
+  <data name="Move" xml:space="preserve">
+    <value>移动</value>
+  </data>
+  <data name="MoveToTop" xml:space="preserve">
+    <value>移至顶部</value>
+  </data>
+  <data name="MoveToBottom" xml:space="preserve">
+    <value>移至底部</value>
+  </data>
+  <data name="MoveToLeft" xml:space="preserve">
+    <value>移至左侧</value>
+  </data>
+  <data name="MoveToRight" xml:space="preserve">
+    <value>移至右侧</value>
+  </data>
+  <data name="CancelMove" xml:space="preserve">
+    <value>取消</value>
+  </data>
   <data name="Timer" xml:space="preserve">
     <value>计时器</value>
   </data>

--- a/wpf/Properties/Resources.zh-TW.resx
+++ b/wpf/Properties/Resources.zh-TW.resx
@@ -126,6 +126,24 @@
   <data name="Stop" xml:space="preserve">
     <value>停止</value>
   </data>
+  <data name="Move" xml:space="preserve">
+    <value>移動</value>
+  </data>
+  <data name="MoveToTop" xml:space="preserve">
+    <value>移至頂部</value>
+  </data>
+  <data name="MoveToBottom" xml:space="preserve">
+    <value>移至底部</value>
+  </data>
+  <data name="MoveToLeft" xml:space="preserve">
+    <value>移至左側</value>
+  </data>
+  <data name="MoveToRight" xml:space="preserve">
+    <value>移至右側</value>
+  </data>
+  <data name="CancelMove" xml:space="preserve">
+    <value>取消</value>
+  </data>
   <data name="Timer" xml:space="preserve">
     <value>計時器</value>
   </data>

--- a/wpf/TimerWindow.xaml
+++ b/wpf/TimerWindow.xaml
@@ -48,9 +48,39 @@
                     <Button x:Name="StopButton"
                             Content="{Binding Source={x:Static properties:Resources.Stop}}"
                             Style="{StaticResource ControlButtonStyle}"
+                            Margin="0,0,0,5"
                             Click="OnTimerStopped"/>
+
+                    <Button x:Name="MoveButton"
+                            Content="{Binding Source={x:Static properties:Resources.Move}}"
+                            Style="{StaticResource ControlButtonStyle}"
+                            Click="OnMoveButtonClicked"/>
                 </StackPanel>
             </StackPanel>
         </Border>
+
+        <!-- 位置選択ポップアップ -->
+        <Popup x:Name="PositionSelectionPopup" StaysOpen="False" Placement="Center">
+            <Border Style="{StaticResource ControlPanelStyle}" Background="White">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Button x:Name="TopButton" Grid.Row="0" Grid.Column="1" Content="↑" Style="{StaticResource PositionButtonStyle}" Tag="Top" Click="OnPositionSelected" ToolTip="{Binding Source={x:Static properties:Resources.MoveToTop}}"/>
+                    <Button x:Name="LeftButton" Grid.Row="1" Grid.Column="0" Content="←" Style="{StaticResource PositionButtonStyle}" Tag="Left" Click="OnPositionSelected" ToolTip="{Binding Source={x:Static properties:Resources.MoveToLeft}}"/>
+                    <Button x:Name="CancelButton" Grid.Row="1" Grid.Column="1" Content="×" Style="{StaticResource PositionButtonStyle}" Click="OnPositionCancelled" ToolTip="{Binding Source={x:Static properties:Resources.CancelMove}}"/>
+                    <Button x:Name="RightButton" Grid.Row="1" Grid.Column="2" Content="→" Style="{StaticResource PositionButtonStyle}" Tag="Right" Click="OnPositionSelected" ToolTip="{Binding Source={x:Static properties:Resources.MoveToRight}}"/>
+                    <Button x:Name="BottomButton" Grid.Row="2" Grid.Column="1" Content="↓" Style="{StaticResource PositionButtonStyle}" Tag="Bottom" Click="OnPositionSelected" ToolTip="{Binding Source={x:Static properties:Resources.MoveToBottom}}"/>
+                </Grid>
+            </Border>
+        </Popup>
     </Grid>
 </Window>

--- a/wpf/TimerWindow.xaml
+++ b/wpf/TimerWindow.xaml
@@ -38,7 +38,7 @@
                           FontSize="{StaticResource HeaderFontSize}"
                           Margin="{StaticResource MediumMargin}"/>
 
-                <StackPanel HorizontalAlignment="Center">
+                <StackPanel x:Name="ButtonStackPanel" HorizontalAlignment="Center">
                     <Button x:Name="PauseResumeButton"
                             Content="{Binding Source={x:Static properties:Resources.Pause}}"
                             Style="{StaticResource ControlButtonStyle}"

--- a/wpf/TimerWindow.xaml.cs
+++ b/wpf/TimerWindow.xaml.cs
@@ -164,6 +164,28 @@ namespace RemMeter
             var logicalScreenLeft = logicalBounds.Left;
             var logicalScreenTop = logicalBounds.Top;
 
+            // レスポンシブレイアウト：位置に応じてボタンの配置を調整
+            if (this.position == TimerPosition.Top || this.position == TimerPosition.Bottom)
+            {
+                // 上下配置時は水平方向にボタンを並べる
+                this.ButtonStackPanel.Orientation = System.Windows.Controls.Orientation.Horizontal;
+
+                // ボタン間のマージンを水平方向用に調整
+                this.PauseResumeButton.Margin = new Thickness(0, 0, 5, 0);
+                this.StopButton.Margin = new Thickness(0, 0, 5, 0);
+                this.MoveButton.Margin = new Thickness(0, 0, 0, 0);
+            }
+            else
+            {
+                // 左右配置時は垂直方向にボタンを並べる
+                this.ButtonStackPanel.Orientation = System.Windows.Controls.Orientation.Vertical;
+
+                // ボタン間のマージンを垂直方向用に調整
+                this.PauseResumeButton.Margin = new Thickness(0, 0, 0, 5);
+                this.StopButton.Margin = new Thickness(0, 0, 0, 5);
+                this.MoveButton.Margin = new Thickness(0, 0, 0, 0);
+            }
+
             switch (this.position)
             {
                 case TimerPosition.Right:

--- a/wpf/TimerWindow.xaml.cs
+++ b/wpf/TimerWindow.xaml.cs
@@ -421,5 +421,64 @@ namespace RemMeter
                 Logger.Error("OnTimerStopped failed - invalid argument", ex);
             }
         }
+
+        private void OnMoveButtonClicked(object sender, RoutedEventArgs e)
+        {
+            // Show the position selection popup
+            if (sender is System.Windows.Controls.Button button)
+            {
+                this.PositionSelectionPopup.PlacementTarget = button;
+                this.PositionSelectionPopup.IsOpen = true;
+            }
+
+            // Hide the button for the current position
+            this.TopButton.Visibility = this.position == TimerPosition.Top ? Visibility.Collapsed : Visibility.Visible;
+            this.BottomButton.Visibility = this.position == TimerPosition.Bottom ? Visibility.Collapsed : Visibility.Visible;
+            this.LeftButton.Visibility = this.position == TimerPosition.Left ? Visibility.Collapsed : Visibility.Visible;
+            this.RightButton.Visibility = this.position == TimerPosition.Right ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void OnPositionSelected(object sender, RoutedEventArgs e)
+        {
+            if (sender is System.Windows.Controls.Button button && button.Tag is string positionString)
+            {
+                Logger.Info($"Position change requested: {positionString}");
+                try
+                {
+                    var newPosition = PositionMapper.ParsePosition(positionString);
+                    if (newPosition != this.position)
+                    {
+                        Logger.Debug($"Changing position from {this.position} to {newPosition}");
+                        this.position = newPosition;
+
+                        // Save the new position to settings
+                        var settings = Properties.Settings.Default;
+                        settings.LastSelectedPosition = this.position.ToString();
+                        settings.Save();
+                        Logger.Debug("Position setting saved");
+
+                        // Update window position and layout
+                        this.SetupWindowPosition();
+                        this.UpdateProgressBar();
+                        Logger.Info($"Position change completed successfully: {newPosition}");
+                    }
+                    else
+                    {
+                        Logger.Debug("Position unchanged - same as current position");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Failed to change position to {positionString}", ex);
+                }
+            }
+
+            this.PositionSelectionPopup.IsOpen = false;
+        }
+
+        private void OnPositionCancelled(object sender, RoutedEventArgs e)
+        {
+            this.PositionSelectionPopup.IsOpen = false;
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a new feature that allows users to change the position of the timer bar while the timer is running.

- A "Change Position" button has been added to the hover control panel. Clicking it enters a selection mode where the user can choose a new edge (`Top`, `Bottom`, `Left`, `Right`) for the timer bar.
- The new position is persisted in the settings and will be restored on the next application launch.
- The feature is implemented with corresponding UI in `TimerWindow.xaml` and logic in `TimerWindow.xaml.cs`. The specification has been updated in `docs/specification.md`.